### PR TITLE
Spelling Error in Title of 14-intro-to-ml.Rmd

### DIFF
--- a/lectures/14-intro-to-ml/14-intro-to-ml.Rmd
+++ b/lectures/14-intro-to-ml/14-intro-to-ml.Rmd
@@ -1,7 +1,7 @@
 ---
 title: Data Science for Economists
 subtitle: Introduction to Machine Learning
-author: Kyle Coombs, adapated from Tyler Ransom
+author: Kyle Coombs, adapted from Tyler Ransom
 date: "Bates College | [ECON/DCS 368](https://github.com/big-data-and-economics)"
 output:
   xaringan::moon_reader:


### PR DESCRIPTION
Corrected Spelling of "adapted." In the title slide of this lecture, it says "**adapated** from Tyler Ransom." 